### PR TITLE
Null check on func for interaction process

### DIFF
--- a/src/LayersTreeSearch.ts
+++ b/src/LayersTreeSearch.ts
@@ -178,7 +178,10 @@ export class LayersTreeSearch
 
         for (let i = 0, l = q.length; i < l; i++)
         {
-            func(event, q[i], false);
+            if (func)
+            {
+                func(event, q[i], false);
+            }
         }
         q = queue[1];
         for (let i = 0, l = q.length; i < l; i++)


### PR DESCRIPTION
Checking if the func is null similar to the other check in the same `_finishInteractionProcess` call. Meant to address https://github.com/pixijs/layers/issues/74 and https://github.com/pixijs/layers/issues/69